### PR TITLE
Updated type to "module"

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.8.0",
   "description": "Perform Affine, Projective or Piecewise Affine transformations over any Image or HTMLElement from only a set of reference points. High-Performance and easy-to-use.",
   "main": "Homography.js",
-  "type": "commonjs",
+  "type": "module",
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
This fixes an error I get when using the npm package because the type is not a "module"

![image](https://github.com/Eric-Canas/Homography.js/assets/16812809/90edfa1e-e73e-4e03-a912-7658ff19312d)
